### PR TITLE
Add Rails 7.0 Support

### DIFF
--- a/lib/instana/backend/agent.rb
+++ b/lib/instana/backend/agent.rb
@@ -32,11 +32,11 @@ module Instana
         @delegate.setup
       end
 
-      def method_missing(mth, *args, &block)
+      def method_missing(mth, *args, **kwargs, &block)
         if @delegate.respond_to?(mth)
-          @delegate.public_send(mth, *args, &block)
+          @delegate.public_send(mth, *args, **kwargs, &block)
         else
-          super(mth, *args, &block)
+          super(mth, *args, **kwargs, &block)
         end
       end
 

--- a/lib/instana/instrumentation/active_record.rb
+++ b/lib/instana/instrumentation/active_record.rb
@@ -8,7 +8,7 @@ module Instana
       IGNORED_SQL = %w[BEGIN COMMIT SET].freeze
       SANITIZE_REGEXP = /('[\s\S][^']*'|\d*\.\d+|\d+|NULL)/i.freeze
 
-      def log(sql, name = 'SQL', binds = [], *args)
+      def log(sql, name = 'SQL', binds = [], *args, **kwargs)
         call_payload = {
           activerecord: {
             adapter: @config[:adapter],
@@ -24,7 +24,7 @@ module Instana
           call_payload[:activerecord][:binds] = mapped
         end
 
-        maybe_trace(call_payload, name) { super(sql, name, binds, *args) }
+        maybe_trace(call_payload, name) { super(sql, name, binds, *args, **kwargs) }
       end
 
       private

--- a/lib/instana/instrumentation/dalli.rb
+++ b/lib/instana/instrumentation/dalli.rb
@@ -61,13 +61,13 @@ module Instana
         ::Instana::Util.method_alias(klass, :request)
       end
 
-      def request(op, *args)
+      def request(op, *args, **kwargs)
         if ::Instana.tracer.tracing? || ::Instana.tracer.tracing_span?(:memcache)
           info_payload = { :memcache => {} }
           info_payload[:memcache][:server] = "#{@hostname}:#{@port}"
           ::Instana.tracer.log_info(info_payload)
         end
-        super(op, *args)
+        super(op, *args, **kwargs)
       end
     end
   end

--- a/lib/instana/instrumentation/resque.rb
+++ b/lib/instana/instrumentation/resque.rb
@@ -23,7 +23,7 @@ module Instana
         { :'resque-client' => kvs }
       end
 
-      def enqueue(klass, *args)
+      def enqueue(klass, *args, **kwargs)
         if Instana.tracer.tracing?
           kvs = collect_kvs(:enqueue, klass, args)
 
@@ -32,11 +32,11 @@ module Instana
             super(klass, *args)
           end
         else
-          super(klass, *args)
+          super(klass, *args, **kwargs)
         end
       end
 
-      def enqueue_to(queue, klass, *args)
+      def enqueue_to(queue, klass, *args, **kwargs)
         if Instana.tracer.tracing? && !Instana.tracer.tracing_span?(:'resque-client')
           kvs = collect_kvs(:enqueue_to, klass, args)
           kvs[:Queue] = queue.to_s if queue
@@ -46,19 +46,19 @@ module Instana
             super(queue, klass, *args)
           end
         else
-          super(queue, klass, *args)
+          super(queue, klass, *args, **kwargs)
         end
       end
 
-      def dequeue(klass, *args)
+      def dequeue(klass, *args, **kwargs)
         if Instana.tracer.tracing?
           kvs = collect_kvs(:dequeue, klass, args)
 
           Instana.tracer.trace(:'resque-client', kvs) do
-            super(klass, *args)
+            super(klass, *args, **kwargs)
           end
         else
-          super(klass, *args)
+          super(klass, *args, **kwargs)
         end
       end
     end

--- a/lib/instana/open_tracing/instana_tracer.rb
+++ b/lib/instana/open_tracing/instana_tracer.rb
@@ -86,9 +86,9 @@ module OpenTracing
       end
     end
 
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, **kwargs, &block)
       ::Instana.logger.warn { "You are invoking `#{m}` on Instana::Tracer via OpenTracing." }
-      super(method, *args, &block)
+      super(method, *args, **kwargs, &block)
     end
 
     def respond_to_missing?(*)

--- a/lib/instana/tracer.rb
+++ b/lib/instana/tracer.rb
@@ -8,9 +8,9 @@ module Instana
   class Tracer
     # Support ::Instana::Tracer.xxx call style for the instantiated tracer
     class << self
-      def method_missing(method, *args, &block)
+      def method_missing(method, *args, **kwargs, &block)
         if ::Instana.tracer.respond_to?(method)
-          ::Instana.tracer.send(method, *args, &block)
+          ::Instana.tracer.send(method, *args, **kwargs, &block)
         else
           super
         end

--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -17,8 +17,8 @@ module OpenTracing
 
     attr_accessor :global_tracer
 
-    def method_missing(method_name, *args, &block)
-      @global_tracer.send(method_name, *args, &block)
+    def method_missing(method_name, *args, **kwargs, &block)
+      @global_tracer.send(method_name, *args, **kwargs, &block)
     end
 
     def respond_to_missing?(name, all)


### PR DESCRIPTION
Use a double splat keyword rest argument, for all delegation methods.

See `Handling argument delegation` section in [Separation of positional and keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0)

<img width="950" alt="Screen Shot 2023-01-26 at 7 11 31 PM" src="https://user-images.githubusercontent.com/3957554/214981690-d85c058d-c705-40dc-8bb7-1ea6fd47a371.png">
